### PR TITLE
Add http client & example

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -29,15 +29,15 @@
         {
             "type": "lldb",
             "request": "launch",
-            "name": "Debug example 'buffer'",
+            "name": "Debug example 'blocking'",
             "cargo": {
                 "args": [
                     "build",
-                    "--example=buffer",
+                    "--example=blocking",
                     "--package=cronet-rs"
                 ],
                 "filter": {
-                    "name": "buffer",
+                    "name": "blocking",
                     "kind": "example"
                 }
             },

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ $ cd cronet-rs
 
 Then, follow the steps to build the project:
 
-1. Get the latest cronet binaries: [build from source](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/components/cronet/build_instructions.md) or get prebuilt binaries from somewhere (if you know a reputable source, [let me know](https://github.com/sleeyax/cronet-rs/issues/new)!).
+1. Get the latest cronet binaries: [build from source](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/components/cronet/build_instructions.md) or download prebuilt binaries from [here](https://github.com/sleeyax/cronet-binaries/releases).
 2. Place all `.h` header files in `src` and all binaries (`.so`, `.dll`, `.dylib`) in `bin`.
 3. Run `cargo build`. This should trigger `bindgen` to (re)generate the bindings.
 
@@ -24,12 +24,12 @@ Then, follow the steps to build the project:
 Maintenance of this project is made possible by all the contributors and sponsors.
 If you'd like to sponsor this project and have your avatar or company logo appear below click [here](https://github.com/sponsors/sleeyax). 💖
 
-<!-- sponsors --><a href="https://github.com/secretkeysio"><img src="https://github.com/secretkeysio.png" width="60px" alt="SecretKeys" /></a><!-- sponsors -->
+<a href="https://github.com/secretkeysio"><img src="https://github.com/secretkeysio.png" width="60px" alt="SecretKeys" /></a>
 
 ## Related projects
 
 Other projects that are related to this project and might interest you:
 
-- [Cronet in C#](https://github.com/sleeyax/CronetSharp)
-- [Cronet in go](https://github.com/SagerNet/cronet-go)
+- [Cronet bindings for C#](https://github.com/sleeyax/CronetSharp)
+- [Cronet bindings for go](https://github.com/sleeyax/cronet-go)
 - [NaïveProxy](https://github.com/klzgrad/naiveproxy)

--- a/examples/blocking.rs
+++ b/examples/blocking.rs
@@ -1,0 +1,12 @@
+use cronet_rs::client::{Body, Client};
+
+fn main() {
+    let client = Client::new();
+    let request = http::Request::builder()
+        .method("GET")
+        .uri("https://httpbin.org/anything")
+        .body(Body::default())
+        .unwrap();
+    let result = client.send(request);
+    println!("{:?}", result);
+}

--- a/examples/blocking.rs
+++ b/examples/blocking.rs
@@ -2,10 +2,22 @@ use cronet_rs::client::{Body, Client};
 
 fn main() {
     let client = Client::new();
+
+    println!("sending GET request...");
     let request = http::Request::builder()
         .method("GET")
         .uri("https://httpbin.org/anything")
         .body(Body::default())
+        .unwrap();
+    let result = client.send(request);
+    print_result(result);
+
+    println!("sending POST request...");
+    let request = http::Request::builder()
+        .method("POST")
+        .uri("https://httpbin.org/anything")
+        .header("content-type", "application/x-www-form-urlencoded")
+        .body(Body::from("Hello, world"))
         .unwrap();
     let result = client.send(request);
     print_result(result);

--- a/examples/blocking.rs
+++ b/examples/blocking.rs
@@ -31,6 +31,6 @@ fn print_result(result: Result<http::Response<Body>, cronet_rs::client::ClientEr
             let body = response.body().as_bytes().unwrap();
             println!("Body: {}", String::from_utf8_lossy(body));
         }
-        Err(error) => println!("Error: {:?}", error),
+        Err(error) => println!("Error: {}", error),
     }
 }

--- a/examples/blocking.rs
+++ b/examples/blocking.rs
@@ -8,5 +8,17 @@ fn main() {
         .body(Body::default())
         .unwrap();
     let result = client.send(request);
-    println!("{:?}", result);
+    print_result(result);
+}
+
+fn print_result(result: Result<http::Response<Body>, cronet_rs::client::ClientError>) {
+    match result {
+        Ok(response) => {
+            println!("Status: {}", response.status());
+            println!("Headers: {:#?}", response.headers());
+            let body = response.body().as_bytes().unwrap();
+            println!("Body: {}", String::from_utf8_lossy(body));
+        }
+        Err(error) => println!("Error: {:?}", error),
+    }
 }

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1,3 +1,5 @@
+use std::slice;
+
 use crate::{
     BufferCallback, Cronet_BufferPtr, Cronet_Buffer_Create, Cronet_Buffer_Destroy,
     Cronet_Buffer_GetData, Cronet_Buffer_GetSize, Cronet_Buffer_InitWithAlloc,
@@ -55,6 +57,10 @@ impl Buffer {
         unsafe { Cronet_Buffer_GetSize(self.ptr) }
     }
 
+    pub(crate) fn data_ptr(&self) -> Cronet_RawDataPtr {
+        unsafe { Cronet_Buffer_GetData(self.ptr) }
+    }
+
     pub fn data<T>(&self) -> Box<T> {
         unsafe {
             let dataPtr: Cronet_RawDataPtr = self.data_ptr();
@@ -62,8 +68,11 @@ impl Buffer {
         }
     }
 
-    pub(crate) fn data_ptr(&self) -> Cronet_RawDataPtr {
-        unsafe { Cronet_Buffer_GetData(self.ptr) }
+    pub fn data_slice<T>(&self, size: usize) -> &[T] {
+        unsafe {
+            let slice = slice::from_raw_parts(self.data_ptr() as *mut T, size);
+            slice
+        }
     }
 
     /// Write arbitrary data to the buffer.

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -83,7 +83,8 @@ impl Buffer {
     ///
     /// * `data` - The data to write to the buffer.
     /// * `data_size` - The size of the data to write to the buffer. Must be less than or equal to the buffer's size.
-    pub fn write<T>(&self, data: Box<T>, data_size: u64) -> Result<(), &'static str> {
+    #[allow(dead_code)]
+    pub(crate) fn write<T>(&self, data: Box<T>, data_size: u64) -> Result<(), &'static str> {
         let src = Box::into_raw(data);
         let src_size = data_size;
         let dst = self.data_ptr() as *mut T;
@@ -95,6 +96,23 @@ impl Buffer {
 
         unsafe {
             std::ptr::swap(src, dst);
+        }
+
+        Ok(())
+    }
+
+    pub(crate) fn write_slice<T>(&self, data: &[T], data_size: u64) -> Result<(), &'static str> {
+        let src = data.as_ptr();
+        let src_size = data_size;
+        let dst = self.data_ptr() as *mut T;
+        let dst_size = self.size();
+
+        if dst_size < src_size {
+            return Err("Buffer is too small to hold the specified data");
+        }
+
+        unsafe {
+            std::ptr::copy_nonoverlapping(src, dst, src_size as usize);
         }
 
         Ok(())

--- a/src/buffer_callback.rs
+++ b/src/buffer_callback.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 
 static mut BUFFER_CALLBACKS: Lazy<CronetCallbacks<Cronet_BufferCallbackPtr, BufferCallbackFn>> =
-    Lazy::new(|| CronetCallbacks::new());
+    Lazy::new(CronetCallbacks::new);
 
 #[no_mangle]
 unsafe extern "C" fn cronetBufferCallbackOnDestroy(

--- a/src/client/body_upload_provider.rs
+++ b/src/client/body_upload_provider.rs
@@ -100,9 +100,9 @@ mod tests {
 
         // Read the modified buffer again by its pointer.
         let buffer = Buffer { ptr };
-        let actual = buffer.data::<&[u8]>();
+        let actual = buffer.data_slice::<u8>(4);
         assert_eq!(actual.len(), expected.len());
-        assert_eq!(*actual, expected.as_bytes());
+        assert_eq!(actual, expected.as_bytes());
 
         buffer.destroy();
     }

--- a/src/client/body_upload_provider.rs
+++ b/src/client/body_upload_provider.rs
@@ -29,9 +29,9 @@ impl<'a> UploadDataProviderHandler for BodyUploadDataProvider<'a> {
                 return;
             }
 
-            match buffer.write(Box::new(bytes), len) {
+            match buffer.write_slice(bytes, len) {
                 Ok(_) => {
-                    sink.on_read_succeeded(len, true); // TODO: implement chunked reads
+                    sink.on_read_succeeded(len, false); // TODO: implement chunked reads
                 }
                 Err(err) => {
                     sink.on_read_error(err);

--- a/src/client/client.rs
+++ b/src/client/client.rs
@@ -1,8 +1,8 @@
 use std::{sync::mpsc, thread};
 
 use crate::{
-    client::ClientError, Destroy, Engine, EngineParams, Executor, UrlRequest, UrlRequestCallback,
-    UrlRequestParams,
+    client::ClientError, Destroy, Engine, EngineParams, EngineResult, Executor, UrlRequest,
+    UrlRequestCallback, UrlRequestParams,
 };
 
 use super::{Body, ResponseHandler, ShouldRedirectFn, Status};
@@ -71,6 +71,9 @@ impl Client {
         );
         // request_parameters.destroy();
         let result = url_request.start();
+        if result != EngineResult::Success {
+            return Result::Err(ClientError::EngineError(result));
+        }
 
         let status = rx.recv().unwrap();
 

--- a/src/client/client.rs
+++ b/src/client/client.rs
@@ -84,3 +84,9 @@ impl Client {
         }
     }
 }
+
+impl Default for Client {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/client/error.rs
+++ b/src/client/error.rs
@@ -1,12 +1,14 @@
 use core::fmt;
 
-use crate::CronetError;
+use crate::{CronetError, EngineResult};
 
 pub enum ClientError {
     /// Internal cronet error.
     CronetError(CronetError),
     /// The request was cancelled.
     CancellationError,
+    /// Unexpected cronet engine result.
+    EngineError(EngineResult),
 }
 
 impl From<CronetError> for ClientError {
@@ -20,6 +22,7 @@ impl fmt::Display for ClientError {
         match self {
             Self::CronetError(error) => write!(f, "{}", error),
             Self::CancellationError => write!(f, "Request was cancelled"),
+            Self::EngineError(error) => write!(f, "Unexpected engine result: {:?}", error),
         }
     }
 }
@@ -29,6 +32,7 @@ impl fmt::Debug for ClientError {
         match self {
             Self::CronetError(error) => write!(f, "{:?}", error),
             Self::CancellationError => write!(f, "Request was cancelled"),
+            Self::EngineError(error) => write!(f, "Unexpected engine result: {:?}", error),
         }
     }
 }

--- a/src/client/error.rs
+++ b/src/client/error.rs
@@ -1,0 +1,34 @@
+use core::fmt;
+
+use crate::CronetError;
+
+pub enum ClientError {
+    /// Internal cronet error.
+    CronetError(CronetError),
+    /// The request was cancelled.
+    CancellationError,
+}
+
+impl From<CronetError> for ClientError {
+    fn from(error: CronetError) -> Self {
+        Self::CronetError(error)
+    }
+}
+
+impl fmt::Display for ClientError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::CronetError(error) => write!(f, "{}", error),
+            Self::CancellationError => write!(f, "Request was cancelled"),
+        }
+    }
+}
+
+impl fmt::Debug for ClientError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::CronetError(error) => write!(f, "{:?}", error),
+            Self::CancellationError => write!(f, "Request was cancelled"),
+        }
+    }
+}

--- a/src/client/error.rs
+++ b/src/client/error.rs
@@ -30,7 +30,7 @@ impl fmt::Display for ClientError {
 impl fmt::Debug for ClientError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::CronetError(error) => write!(f, "{:?}", error),
+            Self::CronetError(error) => write!(f, "{}", error),
             Self::CancellationError => write!(f, "Request was cancelled"),
             Self::EngineError(error) => write!(f, "Unexpected engine result: {:?}", error),
         }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,7 +1,9 @@
 mod body;
 mod body_upload_provider;
 mod client;
+mod response_handler;
 
 pub use body::*;
 pub use body_upload_provider::*;
 pub use client::*;
+pub use response_handler::*;

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,5 +1,6 @@
 mod body;
 mod body_upload_provider;
+#[allow(clippy::module_inception)]
 mod client;
 mod error;
 mod response_handler;

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,9 +1,11 @@
 mod body;
 mod body_upload_provider;
 mod client;
+mod error;
 mod response_handler;
 
 pub use body::*;
 pub use body_upload_provider::*;
 pub use client::*;
+pub use error::*;
 pub use response_handler::*;

--- a/src/client/response_handler.rs
+++ b/src/client/response_handler.rs
@@ -1,0 +1,101 @@
+use std::sync::mpsc::Sender;
+
+use bytes::BufMut;
+use http::Response;
+
+use crate::{
+    Buffer, CronetError, UrlRequest, UrlRequestCallback, UrlRequestCallbackHandler, UrlResponseInfo,
+};
+
+use super::Body;
+
+pub type ShouldRedirectFn = fn(new_location_url: &str) -> bool;
+
+#[derive(Debug)]
+pub enum Status {
+    Success,
+    Canceled,
+    Error(CronetError),
+}
+
+pub struct ResponseHandler {
+    pub should_redirect: ShouldRedirectFn,
+    response: Response<Body>,
+    tx: Sender<(Response<Body>, Status)>,
+}
+
+impl ResponseHandler {
+    pub fn new(should_redirect: ShouldRedirectFn, tx: Sender<(Response<Body>, Status)>) -> Self {
+        Self {
+            should_redirect,
+            response: Response::default(),
+            tx,
+        }
+    }
+}
+
+impl UrlRequestCallbackHandler for ResponseHandler {
+    fn on_redirect_received(
+        &mut self,
+        _: UrlRequestCallback,
+        request: UrlRequest,
+        info: UrlResponseInfo,
+        new_location_url: &str,
+    ) {
+        let redirect = (self.should_redirect)(new_location_url);
+
+        if !redirect {
+            self.response = info.into();
+            return;
+        }
+
+        request.follow_redirect();
+    }
+
+    fn on_response_started(&mut self, _: UrlRequestCallback, _: UrlRequest, info: UrlResponseInfo) {
+        self.response = info.into();
+    }
+
+    fn on_read_completed(
+        &mut self,
+        _: UrlRequestCallback,
+        _: UrlRequest,
+        _: UrlResponseInfo,
+        buffer: Buffer,
+        bytes_read: u64,
+    ) {
+        if bytes_read == 0 {
+            return;
+        }
+
+        let data = buffer.data::<&[u8]>();
+        self.response.body_mut().as_bytes_mut().unwrap().put(data);
+    }
+
+    fn on_succeeded(&mut self, _: UrlRequestCallback, _: UrlRequest, _: UrlResponseInfo) {
+        // TODO: fix lifetime of response to sender
+        self.tx
+            .send((Response::default(), Status::Success))
+            .unwrap();
+    }
+
+    fn on_failed(
+        &mut self,
+        _: UrlRequestCallback,
+        _: UrlRequest,
+        _: UrlResponseInfo,
+        error: CronetError,
+    ) {
+        // TODO: fix lifetime of response to sender
+        self.tx
+            .send((Response::default(), Status::Error(error)))
+            .unwrap();
+    }
+
+    fn on_canceled(&mut self, _: UrlRequestCallback, _: UrlRequest, _: UrlResponseInfo) {
+        // TODO: fix lifetime of response to sender
+        self.tx
+            .send((Response::default(), Status::Canceled))
+            .unwrap();
+    }
+}

--- a/src/client/response_handler.rs
+++ b/src/client/response_handler.rs
@@ -1,10 +1,11 @@
-use std::sync::mpsc::Sender;
+use std::{mem, sync::mpsc::Sender};
 
 use bytes::BufMut;
 use http::Response;
 
 use crate::{
-    Buffer, CronetError, UrlRequest, UrlRequestCallback, UrlRequestCallbackHandler, UrlResponseInfo,
+    Buffer, CronetError, Destroy, UrlRequest, UrlRequestCallback, UrlRequestCallbackHandler,
+    UrlResponseInfo,
 };
 
 use super::Body;
@@ -13,24 +14,46 @@ pub type ShouldRedirectFn = fn(new_location_url: &str) -> bool;
 
 #[derive(Debug)]
 pub enum Status {
-    Success,
+    Success(Response<Body>),
     Canceled,
     Error(CronetError),
 }
 
 pub struct ResponseHandler {
-    pub should_redirect: ShouldRedirectFn,
+    should_redirect: ShouldRedirectFn,
     response: Response<Body>,
-    tx: Sender<(Response<Body>, Status)>,
+    tx: Sender<Status>,
+    buffer: Option<Buffer>,
+    buffer_size: u64,
 }
 
 impl ResponseHandler {
-    pub fn new(should_redirect: ShouldRedirectFn, tx: Sender<(Response<Body>, Status)>) -> Self {
+    pub fn new(should_redirect: ShouldRedirectFn, tx: Sender<Status>) -> Self {
         Self {
             should_redirect,
             response: Response::default(),
             tx,
+            buffer: None,
+            buffer_size: 512,
         }
+    }
+
+    /// Sets the buffer size for reading the response body.
+    /// The default is `512` bytes.
+    pub fn set_buffer_size(&mut self, buffer_size: u64) {
+        self.buffer_size = buffer_size;
+    }
+
+    /// Continues reading the response body.
+    fn read(&mut self, req: UrlRequest) {
+        if let Some(old_buffer) = &self.buffer {
+            old_buffer.destroy();
+        }
+
+        let buffer = Buffer::new_with_size(self.buffer_size);
+        self.buffer = Some(Buffer { ptr: buffer.ptr });
+
+        req.read(buffer);
     }
 }
 
@@ -42,24 +65,27 @@ impl UrlRequestCallbackHandler for ResponseHandler {
         info: UrlResponseInfo,
         new_location_url: &str,
     ) {
-        let redirect = (self.should_redirect)(new_location_url);
-
-        if !redirect {
+        if (self.should_redirect)(new_location_url) {
+            request.follow_redirect();
+        } else {
             self.response = info.into();
-            return;
         }
-
-        request.follow_redirect();
     }
 
-    fn on_response_started(&mut self, _: UrlRequestCallback, _: UrlRequest, info: UrlResponseInfo) {
+    fn on_response_started(
+        &mut self,
+        _: UrlRequestCallback,
+        req: UrlRequest,
+        info: UrlResponseInfo,
+    ) {
         self.response = info.into();
+        self.read(req);
     }
 
     fn on_read_completed(
         &mut self,
         _: UrlRequestCallback,
-        _: UrlRequest,
+        req: UrlRequest,
         _: UrlResponseInfo,
         buffer: Buffer,
         bytes_read: u64,
@@ -68,34 +94,31 @@ impl UrlRequestCallbackHandler for ResponseHandler {
             return;
         }
 
-        let data = buffer.data::<&[u8]>();
+        let data = buffer.data_slice::<u8>(bytes_read as usize);
         self.response.body_mut().as_bytes_mut().unwrap().put(data);
+
+        self.read(req);
     }
 
-    fn on_succeeded(&mut self, _: UrlRequestCallback, _: UrlRequest, _: UrlResponseInfo) {
-        // TODO: fix lifetime of response to sender
-        self.tx
-            .send((Response::default(), Status::Success))
-            .unwrap();
+    fn on_succeeded(&mut self, _: UrlRequestCallback, req: UrlRequest, _: UrlResponseInfo) {
+        req.destroy();
+        let response = mem::replace(&mut self.response, Response::default());
+        self.tx.send(Status::Success(response)).unwrap();
     }
 
     fn on_failed(
         &mut self,
         _: UrlRequestCallback,
-        _: UrlRequest,
+        req: UrlRequest,
         _: UrlResponseInfo,
         error: CronetError,
     ) {
-        // TODO: fix lifetime of response to sender
-        self.tx
-            .send((Response::default(), Status::Error(error)))
-            .unwrap();
+        req.destroy();
+        self.tx.send(Status::Error(error)).unwrap();
     }
 
-    fn on_canceled(&mut self, _: UrlRequestCallback, _: UrlRequest, _: UrlResponseInfo) {
-        // TODO: fix lifetime of response to sender
-        self.tx
-            .send((Response::default(), Status::Canceled))
-            .unwrap();
+    fn on_canceled(&mut self, _: UrlRequestCallback, req: UrlRequest, _: UrlResponseInfo) {
+        req.destroy();
+        self.tx.send(Status::Canceled).unwrap();
     }
 }

--- a/src/client/response_handler.rs
+++ b/src/client/response_handler.rs
@@ -102,7 +102,7 @@ impl UrlRequestCallbackHandler for ResponseHandler {
 
     fn on_succeeded(&mut self, _: UrlRequestCallback, req: UrlRequest, _: UrlResponseInfo) {
         req.destroy();
-        let response = mem::replace(&mut self.response, Response::default());
+        let response = mem::take(&mut self.response);
         self.tx.send(Status::Success(response)).unwrap();
     }
 

--- a/src/date_time.rs
+++ b/src/date_time.rs
@@ -48,6 +48,12 @@ impl Destroy for DateTime {
     }
 }
 
+impl Default for DateTime {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::time::UNIX_EPOCH;

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -110,6 +110,12 @@ impl Destroy for Engine {
     }
 }
 
+impl Default for Engine {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::Destroy;

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -75,21 +75,21 @@ impl Engine {
     }
 
     /// A human-readable version string of the engine.
-    pub fn version(&self) -> String {
+    pub fn version(&self) -> &str {
         unsafe {
             let version = Cronet_Engine_GetVersionString(self.ptr);
             let version = CStr::from_ptr(version);
-            version.to_string_lossy().into_owned()
+            version.to_str().unwrap()
         }
     }
 
     /// Returns the default value of the `User-Agent` header.
     /// Can be accessed before `StartWithParams()` is called.
-    pub fn default_user_agent(&self) -> String {
+    pub fn default_user_agent(&self) -> &str {
         unsafe {
             let version = Cronet_Engine_GetDefaultUserAgent(self.ptr);
             let version = CStr::from_ptr(version);
-            version.to_string_lossy().into_owned()
+            version.to_str().unwrap()
         }
     }
 

--- a/src/engine_params.rs
+++ b/src/engine_params.rs
@@ -273,6 +273,12 @@ impl Destroy for EngineParams {
     }
 }
 
+impl Default for EngineParams {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[derive(Debug, PartialEq)]
 pub enum HttpCacheMode {
     /// Disable HTTP cache.

--- a/src/engine_params.rs
+++ b/src/engine_params.rs
@@ -57,12 +57,12 @@ impl EngineParams {
     }
 
     /// Returns the `User-Agent` header value.
-    pub fn user_agent(&self) -> String {
+    pub fn user_agent(&self) -> &str {
         unsafe {
             let c_str = Cronet_EngineParams_user_agent_get(self.ptr);
             let c_str = CStr::from_ptr(c_str);
             let str_slice = c_str.to_str().unwrap();
-            str_slice.to_owned()
+            str_slice
         }
     }
 
@@ -75,12 +75,12 @@ impl EngineParams {
     }
 
     /// Returns the `Accept-Language` header value.
-    pub fn accept_language(&self) -> String {
+    pub fn accept_language(&self) -> &str {
         unsafe {
             let c_str = Cronet_EngineParams_accept_language_get(self.ptr);
             let c_str = CStr::from_ptr(c_str);
             let str_slice = c_str.to_str().unwrap();
-            str_slice.to_owned()
+            str_slice
         }
     }
 
@@ -94,12 +94,12 @@ impl EngineParams {
     }
 
     /// Returns the directory for HTTP Cache and Prefs Storage.
-    pub fn storage_path(&self) -> String {
+    pub fn storage_path(&self) -> &str {
         unsafe {
             let c_str = Cronet_EngineParams_storage_path_get(self.ptr);
             let c_str = CStr::from_ptr(c_str);
             let str_slice = c_str.to_str().unwrap();
-            str_slice.to_owned()
+            str_slice
         }
     }
 
@@ -257,12 +257,12 @@ impl EngineParams {
         }
     }
 
-    pub fn experimental_options(&self) -> String {
+    pub fn experimental_options(&self) -> &str {
         unsafe {
             let c_str = Cronet_EngineParams_experimental_options_get(self.ptr);
             let c_str = CStr::from_ptr(c_str);
             let str_slice = c_str.to_str().unwrap();
-            str_slice.to_owned()
+            str_slice
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -116,6 +116,12 @@ impl Destroy for CronetError {
     }
 }
 
+impl Default for CronetError {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl fmt::Display for CronetError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(

--- a/src/error.rs
+++ b/src/error.rs
@@ -49,10 +49,10 @@ impl CronetError {
     }
 
     /// Get the error message.
-    pub fn message(&self) -> String {
+    pub fn message(&self) -> &str {
         unsafe {
             let c_message = Cronet_Error_message_get(self.ptr);
-            let message = CStr::from_ptr(c_message).to_string_lossy().into_owned();
+            let message = CStr::from_ptr(c_message).to_str().unwrap();
             message
         }
     }

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 
 static mut EXECUTOR_CALLBACKS: Lazy<CronetCallbacks<Cronet_ExecutorPtr, ExecutorExecuteFn>> =
-    Lazy::new(|| CronetCallbacks::new());
+    Lazy::new(CronetCallbacks::new);
 
 #[no_mangle]
 unsafe extern "C" fn cronetExecutorOnExecute(

--- a/src/http_header.rs
+++ b/src/http_header.rs
@@ -58,6 +58,12 @@ impl Destroy for HttpHeader {
     }
 }
 
+impl Default for HttpHeader {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::Destroy;

--- a/src/http_header.rs
+++ b/src/http_header.rs
@@ -20,12 +20,10 @@ impl HttpHeader {
     }
 
     /// Get the name of this header.
-    pub fn name(&self) -> String {
+    pub fn name(&self) -> &'static str {
         unsafe {
             let c_name = Cronet_HttpHeader_name_get(self.ptr);
-            let name = std::ffi::CStr::from_ptr(c_name)
-                .to_string_lossy()
-                .into_owned();
+            let name = std::ffi::CStr::from_ptr(c_name).to_str().unwrap();
             name
         }
     }
@@ -38,10 +36,10 @@ impl HttpHeader {
         }
     }
 
-    pub fn value(&self) -> String {
+    pub fn value(&self) -> &'static str {
         unsafe {
             let c_value = Cronet_HttpHeader_value_get(self.ptr);
-            let value = CStr::from_ptr(c_value).to_string_lossy().into_owned();
+            let value = CStr::from_ptr(c_value).to_str().unwrap();
             value
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ mod annotation;
 mod buffer;
 mod buffer_callback;
 #[cfg(feature = "client")]
-mod client;
+pub mod client;
 mod date_time;
 mod destroy;
 mod engine;

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -161,24 +161,15 @@ impl Metrics {
     }
 
     pub fn socket_reused(&self) -> bool {
-        unsafe {
-            let reused = Cronet_Metrics_socket_reused_get(self.ptr);
-            reused
-        }
+        unsafe { Cronet_Metrics_socket_reused_get(self.ptr) }
     }
 
     pub fn sent_byte_count(&self) -> i64 {
-        unsafe {
-            let count = Cronet_Metrics_sent_byte_count_get(self.ptr);
-            count
-        }
+        unsafe { Cronet_Metrics_sent_byte_count_get(self.ptr) }
     }
 
     pub fn received_byte_count(&self) -> i64 {
-        unsafe {
-            let count = Cronet_Metrics_received_byte_count_get(self.ptr);
-            count
-        }
+        unsafe { Cronet_Metrics_received_byte_count_get(self.ptr) }
     }
 
     pub fn set_request_start(&self, datetime: DateTime) {
@@ -281,6 +272,12 @@ impl Metrics {
 impl Destroy for Metrics {
     fn destroy(&self) {
         unsafe { Cronet_Metrics_Destroy(self.ptr) }
+    }
+}
+
+impl Default for Metrics {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/src/public_key_pins.rs
+++ b/src/public_key_pins.rs
@@ -111,6 +111,12 @@ impl Destroy for PublicKeyPins {
     }
 }
 
+impl Default for PublicKeyPins {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::time::UNIX_EPOCH;

--- a/src/public_key_pins.rs
+++ b/src/public_key_pins.rs
@@ -33,10 +33,10 @@ impl PublicKeyPins {
         }
     }
 
-    pub fn host(&self) -> String {
+    pub fn host(&self) -> &str {
         unsafe {
             let c_str = Cronet_PublicKeyPins_host_get(self.ptr);
-            let host = CStr::from_ptr(c_str).to_string_lossy().into_owned();
+            let host = CStr::from_ptr(c_str).to_str().unwrap();
             host
         }
     }
@@ -58,10 +58,10 @@ impl PublicKeyPins {
         unsafe { Cronet_PublicKeyPins_pins_sha256_size(self.ptr) }
     }
 
-    pub fn at(&self, index: u32) -> String {
+    pub fn at(&self, index: u32) -> &str {
         unsafe {
             let c_str = Cronet_PublicKeyPins_pins_sha256_at(self.ptr, index);
-            CStr::from_ptr(c_str).to_string_lossy().into_owned()
+            CStr::from_ptr(c_str).to_str().unwrap()
         }
     }
 

--- a/src/quic_hint.rs
+++ b/src/quic_hint.rs
@@ -65,6 +65,12 @@ impl Destroy for QuicHint {
     }
 }
 
+impl Default for QuicHint {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::Destroy;

--- a/src/quic_hint.rs
+++ b/src/quic_hint.rs
@@ -28,10 +28,10 @@ impl QuicHint {
         }
     }
 
-    pub fn host(&self) -> String {
+    pub fn host(&self) -> &str {
         unsafe {
             let c_str = Cronet_QuicHint_host_get(self.ptr);
-            let host = CStr::from_ptr(c_str).to_string_lossy().into_owned();
+            let host = CStr::from_ptr(c_str).to_str().unwrap();
             host
         }
     }

--- a/src/request_finished_info.rs
+++ b/src/request_finished_info.rs
@@ -87,6 +87,12 @@ impl Destroy for RequestFinishedInfo {
     }
 }
 
+impl Default for RequestFinishedInfo {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// Enum representing the reason why the request finished.
 #[derive(Debug, PartialEq)]
 pub enum RequestFinishedInfoReason {

--- a/src/request_finished_info_listener.rs
+++ b/src/request_finished_info_listener.rs
@@ -10,7 +10,7 @@ use crate::{
 
 static mut REQUEST_FINISHED_INFO_LISTENER_CALLBACKS: Lazy<
     CronetCallbacks<Cronet_RequestFinishedInfoListenerPtr, OnRequestFinishedFn>,
-> = Lazy::new(|| CronetCallbacks::new());
+> = Lazy::new(CronetCallbacks::new);
 
 #[no_mangle]
 unsafe extern "C" fn cronetOnRequestFinished(
@@ -50,10 +50,9 @@ impl RequestFinishedInfoListener {
         }
     }
 
-    pub fn set_client_context(&self, raw_data: Cronet_RawDataPtr) {
-        unsafe {
-            Cronet_RequestFinishedInfoListener_SetClientContext(self.ptr, raw_data);
-        }
+    #[allow(clippy::missing_safety_doc)]
+    pub unsafe fn set_client_context(&self, raw_data: Cronet_RawDataPtr) {
+        Cronet_RequestFinishedInfoListener_SetClientContext(self.ptr, raw_data);
     }
 }
 
@@ -84,7 +83,9 @@ mod tests {
     #[test]
     fn it_sets_client_context() {
         let listener = super::RequestFinishedInfoListener::new(|_, _, _, _| {});
-        listener.set_client_context(std::ptr::null_mut());
+        unsafe {
+            listener.set_client_context(std::ptr::null_mut());
+        }
         listener.destroy();
     }
 }

--- a/src/runnable.rs
+++ b/src/runnable.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 
 static mut RUNNABLE_CALLBACKS: Lazy<CronetCallbacks<Cronet_RunnablePtr, RunnableRunFn>> =
-    Lazy::new(|| CronetCallbacks::new());
+    Lazy::new(CronetCallbacks::new);
 
 #[no_mangle]
 unsafe extern "C" fn cronetRunnableOnRun(selfPtr: Cronet_RunnablePtr) {

--- a/src/upload_data_provider.rs
+++ b/src/upload_data_provider.rs
@@ -177,7 +177,7 @@ mod tests {
 
         fn read(&self, _: UploadDataProvider, sink: UploadDataSink, buffer: Buffer) {
             let size = buffer.size();
-            sink.on_read_succeeded(size, true);
+            sink.on_read_succeeded(size, false);
         }
 
         fn rewind(&mut self, _: UploadDataProvider, sink: UploadDataSink) {

--- a/src/upload_data_provider.rs
+++ b/src/upload_data_provider.rs
@@ -11,7 +11,7 @@ use crate::{
 
 static mut UPLOAD_DATA_PROVIDER_CALLBACKS: Lazy<
     CronetCallbacks<Cronet_UploadDataProviderPtr, Box<dyn UploadDataProviderHandler>>,
-> = Lazy::new(|| CronetCallbacks::new());
+> = Lazy::new(CronetCallbacks::new);
 
 #[no_mangle]
 unsafe extern "C" fn cronetUploadDataProviderGetLength(
@@ -19,7 +19,7 @@ unsafe extern "C" fn cronetUploadDataProviderGetLength(
 ) -> i64 {
     let lockedMap = UPLOAD_DATA_PROVIDER_CALLBACKS.map().lock().unwrap();
     let callback = lockedMap.get(&selfPtr).unwrap();
-    return callback.length(UploadDataProvider { ptr: selfPtr });
+    callback.length(UploadDataProvider { ptr: selfPtr })
 }
 
 #[no_mangle]
@@ -105,8 +105,9 @@ impl UploadDataProvider {
         }
     }
 
-    pub fn set_client_context(&self, client_context: Cronet_ClientContext) {
-        unsafe { Cronet_UploadDataProvider_SetClientContext(self.ptr, client_context) }
+    #[allow(clippy::missing_safety_doc)]
+    pub unsafe fn set_client_context(&self, client_context: Cronet_ClientContext) {
+        Cronet_UploadDataProvider_SetClientContext(self.ptr, client_context)
     }
 
     pub fn client_context(&self) -> Cronet_ClientContext {

--- a/src/upload_data_sink.rs
+++ b/src/upload_data_sink.rs
@@ -11,7 +11,7 @@ use crate::{
 
 static mut UPLOAD_DATA_SINK_CALLBACKS: Lazy<
     CronetCallbacks<Cronet_UploadDataSinkPtr, UploadDataSinkCallbacks>,
-> = Lazy::new(|| CronetCallbacks::new());
+> = Lazy::new(CronetCallbacks::new);
 
 #[no_mangle]
 unsafe extern "C" fn cronetUploadDataSinkOnReadSucceeded(

--- a/src/upload_data_sink.rs
+++ b/src/upload_data_sink.rs
@@ -163,7 +163,7 @@ mod tests {
             on_rewind_succeeded: |_| println!("on_rewind_succeeded"),
             on_rewind_error: |_, _| println!("on_rewind_error"),
         });
-        upload_data_sink.on_read_succeeded(10, true);
+        upload_data_sink.on_read_succeeded(10, false);
         upload_data_sink.on_rewind_succeeded();
         upload_data_sink.on_read_error("error");
         upload_data_sink.on_rewind_error("error");

--- a/src/url_request.rs
+++ b/src/url_request.rs
@@ -134,3 +134,9 @@ impl Destroy for UrlRequest {
         }
     }
 }
+
+impl Default for UrlRequest {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/url_request.rs
+++ b/src/url_request.rs
@@ -36,11 +36,11 @@ impl UrlRequest {
     /// * `executor` - Executor on which all callbacks will be invoked.
     pub fn init_with_params(
         &self,
-        engine: Engine,
+        engine: &Engine,
         url: &str,
-        params: UrlRequestParams,
-        callback: UrlRequestCallback,
-        executor: Executor,
+        params: &UrlRequestParams,
+        callback: &UrlRequestCallback,
+        executor: &Executor,
     ) -> EngineResult {
         unsafe {
             let c_str = CString::new(url).unwrap();

--- a/src/url_request_callback.rs
+++ b/src/url_request_callback.rs
@@ -11,7 +11,7 @@ use crate::{
 
 static mut URL_REQUEST_CALLBACK_CALLBACKS: Lazy<
     CronetCallbacks<Cronet_UrlRequestCallbackPtr, Box<dyn UrlRequestCallbackHandler>>,
-> = Lazy::new(|| CronetCallbacks::new());
+> = Lazy::new(CronetCallbacks::new);
 
 #[no_mangle]
 unsafe extern "C" fn cronetUrlRequestCallbackOnRedirectReceived(

--- a/src/url_request_params.rs
+++ b/src/url_request_params.rs
@@ -270,6 +270,12 @@ impl Destroy for UrlRequestParams {
     }
 }
 
+impl Default for UrlRequestParams {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[cfg(feature = "client")]
 impl<T> From<Request<T>> for UrlRequestParams
 where

--- a/src/url_request_params.rs
+++ b/src/url_request_params.rs
@@ -53,12 +53,12 @@ impl UrlRequestParams {
         }
     }
 
-    pub fn method(&self) -> String {
+    pub fn method(&self) -> &str {
         unsafe {
             let c_str = Cronet_UrlRequestParams_http_method_get(self.ptr);
             let c_str = CStr::from_ptr(c_str);
             let str_slice = c_str.to_str().unwrap();
-            str_slice.to_owned()
+            str_slice
         }
     }
 

--- a/src/url_request_status_listener.rs
+++ b/src/url_request_status_listener.rs
@@ -8,7 +8,7 @@ use crate::{
 
 static mut URL_REQUEST_STATUS_LISTENER_CALLBACKS: Lazy<
     CronetCallbacks<Cronet_UrlRequestStatusListenerPtr, UrlRequestStatusListenerOnStatusFn>,
-> = Lazy::new(|| CronetCallbacks::new());
+> = Lazy::new(CronetCallbacks::new);
 
 #[no_mangle]
 unsafe extern "C" fn cronetUrlRequestStatusListenerOnStatus(
@@ -50,6 +50,12 @@ impl Destroy for UrlRequestStatusListener {
             lockedMap.remove(&self.ptr);
             Cronet_UrlRequestStatusListener_Destroy(self.ptr);
         }
+    }
+}
+
+impl Default for UrlRequestStatusListener {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/src/url_response_info.rs
+++ b/src/url_response_info.rs
@@ -109,10 +109,7 @@ impl UrlResponseInfo {
     }
 
     pub fn header_size(&self) -> u32 {
-        unsafe {
-            let size = Cronet_UrlResponseInfo_all_headers_list_size(self.ptr);
-            size
-        }
+        unsafe { Cronet_UrlResponseInfo_all_headers_list_size(self.ptr) }
     }
 
     pub fn header_at(&self, index: u32) -> HttpHeader {
@@ -200,7 +197,14 @@ impl Destroy for UrlResponseInfo {
     }
 }
 
+impl Default for UrlResponseInfo {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[cfg(feature = "client")]
+#[allow(clippy::from_over_into)]
 impl<T> Into<Response<T>> for UrlResponseInfo
 where
     T: Default,

--- a/src/url_response_info.rs
+++ b/src/url_response_info.rs
@@ -1,5 +1,7 @@
 use std::ffi::{CStr, CString};
 
+use http::{HeaderValue, Response, StatusCode, Version};
+
 use crate::{
     Cronet_UrlResponseInfoPtr, Cronet_UrlResponseInfo_Create, Cronet_UrlResponseInfo_Destroy,
     Cronet_UrlResponseInfo_all_headers_list_add, Cronet_UrlResponseInfo_all_headers_list_at,
@@ -31,11 +33,11 @@ impl UrlResponseInfo {
 
     /// The URL the response is for.
     /// This is the URL after following redirects, so it may not be the originally requested URL
-    pub fn url(&self) -> String {
+    pub fn url(&self) -> &str {
         unsafe {
             let url = Cronet_UrlResponseInfo_url_get(self.ptr);
             let url = CStr::from_ptr(url);
-            url.to_string_lossy().into_owned()
+            url.to_str().unwrap()
         }
     }
 
@@ -54,11 +56,11 @@ impl UrlResponseInfo {
 
     /// The URL at the given index in the chain.
     /// The first entry is the originally requested URL; the following entries are redirects followed.
-    pub fn url_chain_at(&self, index: u32) -> String {
+    pub fn url_chain_at(&self, index: u32) -> &str {
         unsafe {
             let url = Cronet_UrlResponseInfo_url_chain_at(self.ptr, index);
             let url = CStr::from_ptr(url);
-            url.to_string_lossy().into_owned()
+            url.to_str().unwrap()
         }
     }
 
@@ -91,11 +93,11 @@ impl UrlResponseInfo {
 
     /// The HTTP status text of the status line.
     /// For example, if the request received a "HTTP/1.1 200 OK" response, this method returns "OK".
-    pub fn status_text(&self) -> String {
+    pub fn status_text(&self) -> &str {
         unsafe {
             let text = Cronet_UrlResponseInfo_http_status_text_get(self.ptr);
             let text = CStr::from_ptr(text);
-            text.to_string_lossy().into_owned()
+            text.to_str().unwrap()
         }
     }
 
@@ -146,11 +148,12 @@ impl UrlResponseInfo {
     /// The protocol (for example 'quic/1+spdy/3') negotiated with the server.
     /// An empty string if no protocol was negotiated, the protocol is
     /// not known, or when using plain HTTP or HTTPS.
-    pub fn negotiated_protocol(&self) -> String {
+    pub fn negotiated_protocol(&self) -> &'static str {
         unsafe {
             let protocol = Cronet_UrlResponseInfo_negotiated_protocol_get(self.ptr);
             let protocol = CStr::from_ptr(protocol);
-            protocol.to_string_lossy().into_owned()
+            let protocol = protocol.to_str().unwrap();
+            protocol
         }
     }
 
@@ -162,11 +165,11 @@ impl UrlResponseInfo {
     }
 
     /// The proxy server that was used for the request.
-    pub fn proxy_server(&self) -> String {
+    pub fn proxy_server(&self) -> &'static str {
         unsafe {
             let server = Cronet_UrlResponseInfo_proxy_server_get(self.ptr);
-            let server = CStr::from_ptr(server);
-            server.to_string_lossy().into_owned()
+            let server = CStr::from_ptr(server).to_str().unwrap();
+            server
         }
     }
 


### PR DESCRIPTION
Added a simple initial 'blocking' HTTP client implementation. The client is blocking in the sense that it uses a channel to wait for a response from the engine. But keep in mind that the cronet engine by itself internally already handles things asynchronously via callbacks. That being said, a proper async client implementation is still warranted #3.

The client feature is enabled by default in `cargo.toml` and can be disabled by advanced users who only wish to use the raw bindings or create a custom client wrapper. 